### PR TITLE
fix: Add detailed logging and CORS headers to chat API

### DIFF
--- a/src/services/chatApi.ts
+++ b/src/services/chatApi.ts
@@ -18,7 +18,8 @@ export const sendChatMessage = async (request: ChatApiRequest): Promise<ChatApiR
       url: WEBHOOK_URL,
       userProfile: request.userProfile ? 'included' : 'not included',
       userLocation: request.userLocation ? 'included' : 'not included',
-      context: request.context ? 'included' : 'not included'
+      context: request.context ? 'included' : 'not included',
+      request: request // Log the entire request object
     });
     
     const response = await fetch(WEBHOOK_URL, {
@@ -30,10 +31,13 @@ export const sendChatMessage = async (request: ChatApiRequest): Promise<ChatApiR
         'User-Agent': 'DiscoverDiani/1.0',
       },
       body: JSON.stringify(request),
+      cache: 'no-cache', // Prevent caching
+      mode: 'cors', // Enable CORS
     });
 
     console.log('Webhook response status:', response.status);
     console.log('Webhook response headers:', Object.fromEntries(response.headers.entries()));
+    console.log('Webhook response:', response); // Log the entire response object
 
     if (!response.ok) {
       console.error(`Webhook error! status: ${response.status} ${response.statusText}`);


### PR DESCRIPTION
This commit addresses a 404 error when sending chat messages to the n8n webhook.

The following changes have been made:
- Added `cache: 'no-cache'` and `mode: 'cors'` to the `fetch` request in `src/services/chatApi.ts` to prevent caching and CORS issues.
- Added detailed logging for the entire `request` and `response` objects to help with debugging.